### PR TITLE
Added bill item notes

### DIFF
--- a/pos/webpos/static/css/screen.css
+++ b/pos/webpos/static/css/screen.css
@@ -129,6 +129,24 @@ main aside .total {
   white-space: nowrap;
   font-weight: bold;
 }
+main aside .notes {
+  padding-left: 12px;
+  padding-right: 5px;
+}
+main aside .notes textarea {
+  resize: none;
+  overflow: hidden;
+  -moz-transition: height 200ms;
+  -o-transition: height 200ms;
+  -webkit-transition: height 200ms;
+  transition: height 200ms;
+  width: 100%;
+  height: 1em;
+}
+main aside .notes textarea:focus {
+  overflow: auto;
+  height: 5em;
+}
 main footer {
   clear: both;
   text-align: center;

--- a/pos/webpos/static/css/screen.css
+++ b/pos/webpos/static/css/screen.css
@@ -34,7 +34,6 @@ main {
 main header {
   height: 10px;
   text-align: center;
-  background: url("http://www.paeseinfesta.it/templates/sonne/css/images/Header.png") center top;
 }
 main article {
   float: left;

--- a/pos/webpos/static/js/models/order.js
+++ b/pos/webpos/static/js/models/order.js
@@ -4,7 +4,7 @@
  */
 function OrderModel () {
     var that = riot.observable(this),
-        /** @type {Object} The store. An object formatted as { id_item : { "category" : id_category, "id" : id_item, "name" : "item_name", "price" : item_price, "qty" : item_ordered_qty } } */
+        /** @type {Object} The store. An object formatted as { id_item : { "category" : id_category, "id" : id_item, "name" : "item_name", "price" : item_price, "qty" : item_ordered_qty, "notes" : item_notes } } */
         hStore = {},
         /** @type {Object} The categories object formatted as { id_number : { "id" : number, "name" : string, "priority" : number } */
         hCategories = {};
@@ -18,6 +18,7 @@ function OrderModel () {
      * @param {String} hProd.name     The product name.
      * @param {Number} hProd.qty      The ordered quantity.
      * @param {Number} hProd.price    The product price.
+     * @param {Number} hProd.notes    The product notes.
      */
     that.addProduct = function (hProd) {
         var hStoreProd = hStore[hProd.id];
@@ -68,6 +69,21 @@ function OrderModel () {
                 deleteProduct(hProd.id);
             }
             triggerAddToBill();
+        }
+    };
+
+    /**
+     * Decrement quantity of a product.
+     * @param {Object} hProd       The product data.
+     * @param {Number} hProd.id    The product ID.
+     * @param {String} hProd.notes The product notes.
+     */
+    that.addNotesToProduct = function (hProd) {
+        var hStoreProd = hStore[hProd.id];
+
+        // Add notes to a product already in the store
+        if (hStoreProd) {
+            hStoreProd.notes = hProd.notes;
         }
     };
 
@@ -166,7 +182,10 @@ function OrderModel () {
             };
 
         for (nId in hStore) {
-            hData.items[hStore[nId].name] = hStore[nId].qty;
+            hData.items[hStore[nId].name] = {
+                qty   : hStore[nId].qty,
+                notes : hStore[nId].notes
+            };
         }
         $.pif.ajaxCall({
             url : '/webpos/commit/',

--- a/pos/webpos/static/js/presenters/order_presenter.js
+++ b/pos/webpos/static/js/presenters/order_presenter.js
@@ -365,7 +365,7 @@ function orderPresenter (hModel) {
                 }
             };
 
-        hMod.commitBill(elNameInput.value, fnAjaxSuccess, function (nStatus) {
+        hMod.commitBill(elNameInput.value, fnAjaxSuccess, function () {
             showAlert("<p>Errore di comunicazione col server</p>Ritenta o chiama un tecnico");
         });
     }
@@ -402,10 +402,8 @@ function orderPresenter (hModel) {
             elButton;
         for (sName in hItems) {
             aValues = hItems[sName];
-            // aValues[0] = quantity, aValues[1] = price
             nQty = aValues[0];
             elButton = document.querySelector("[data-name='" + sName +"']");
-            // @todo Find the button
             if (nQty !== null && nQty <= 5) {
                 elButton.classList.add('badge');
                 elButton.dataset.badge = nQty;

--- a/pos/webpos/static/js/presenters/order_presenter.js
+++ b/pos/webpos/static/js/presenters/order_presenter.js
@@ -21,6 +21,8 @@ function orderPresenter (hModel) {
         elNameInput         = document.getElementsByClassName('customer-name')[0],
         /** @type {HTMLAnchorElement} */
         elPrintBtn          = document.getElementsByClassName('btn-print-bill')[0],
+        /** @type {HTMLTextAreaElement} */
+        elItemNotes         = document.getElementsByClassName('item-notes')[0],
         /** @type {HTMLAnchorElement} */
         elAlertBtn          = document.getElementsByClassName('btn-ok-alert')[0],
         /** @type {HTMLTableElement} */
@@ -37,6 +39,8 @@ function orderPresenter (hModel) {
         sTplBillCategory    = document.getElementsByClassName('billCategoryRow')[0].innerHTML,
         /** @type {String} */
         sTplBillItem        = document.getElementsByClassName('billItemRow')[0].innerHTML,
+        /** @type {String} */
+        sTplBillNotes       = document.getElementsByClassName('billItemNotes')[0].innerHTML,
         /** @type {String} */
         sTplBillSeparator   = document.getElementsByClassName('billSeparatorRow')[0].innerHTML;
 
@@ -80,6 +84,15 @@ function orderPresenter (hModel) {
         }
     }
 
+    function onKeyupMenu (evt) {
+        evt.preventDefault();
+        if (evt.target.tagName === 'INPUT') {
+            enablePrintButton(evt.target.value.length > 2);
+        } else if (evt.target.tagName === 'TEXTAREA') {
+            addNotesToProduct(evt.target);
+        }
+    }
+
     function onClickBtnAlert (evt) {
         evt.preventDefault();
         if (evt.target.tagName === 'A') {
@@ -108,13 +121,6 @@ function orderPresenter (hModel) {
     function hideAlert () {
         elAlertPanel.classList.add('hidden');
         elMask.classList.add('hidden');
-    }
-
-    function onWriteName (evt) {
-        evt.preventDefault();
-        if (evt.target.tagName === 'INPUT') {
-            enablePrintButton(evt.target.value.length > 2);
-        }
     }
 
     /**
@@ -159,7 +165,8 @@ function orderPresenter (hModel) {
             category : nIdCat,
             name     : elProductBtn.innerHTML,
             qty      : 1,
-            price    : parseFloat(elProductBtn.dataset.price)
+            price    : parseFloat(elProductBtn.dataset.price),
+            notes    : ""
         });
     }
 
@@ -182,6 +189,15 @@ function orderPresenter (hModel) {
         hMod.decrementProduct({
             id  : nId,
             qty : 1
+        });
+    }
+
+    function addNotesToProduct (elTextarea) {
+        var nId = parseInt(elTextarea.dataset.id, 10);
+
+        hMod.addNotesToProduct({
+            id    : nId,
+            notes : elTextarea.value
         });
     }
 
@@ -221,6 +237,7 @@ function orderPresenter (hModel) {
                 }
             }
 
+            // Bill item
             sHTMLRow = riot.render(sTplBillItem, {
                 id     : hItem.id,
                 name   : hItem.name,
@@ -230,6 +247,14 @@ function orderPresenter (hModel) {
             elTr = document.createElement('tr');
 
             elTr.innerHTML = sHTMLRow;
+            elBillTable.appendChild(elTr);
+
+            //Notes
+            elTr = document.createElement('tr');
+            elTr.innerHTML = riot.render(sTplBillNotes, {
+                id    : hItem.id,
+                notes : hItem.notes
+            });
             elBillTable.appendChild(elTr);
 
             nLastCategory = hItem.category
@@ -397,7 +422,7 @@ function orderPresenter (hModel) {
     addEventsListener(elCategoryContainer, 'click touch', onClickBtnCategory);
     addEventsListener(elProductsContainer, 'click touch', onClickBtnProduct);
     addEventsListener(elAside,             'click touch', onClickMenu);
-    addEventsListener(elNameInput,         'keyup',       onWriteName);
+    addEventsListener(elAside,             'keyup',       onKeyupMenu);
     addEventsListener(elMain,              'dragstart',   disableEvent);
     addEventsListener(elAlertBtn,          'click touch', onClickBtnAlert);
 

--- a/pos/webpos/static/js/presenters/order_presenter.js
+++ b/pos/webpos/static/js/presenters/order_presenter.js
@@ -400,7 +400,6 @@ function orderPresenter (hModel) {
     addEventsListener(elNameInput,         'keyup',       onWriteName);
     addEventsListener(elMain,              'dragstart',   disableEvent);
     addEventsListener(elAlertBtn,          'click touch', onClickBtnAlert);
-    document.getElementsByTagName('form')[0].addEventListener('submit', function(e){e.preventDefault()});
 
     hMod.setCategories(getCategories());
     nUpdateLoop = setUploadLoop();

--- a/pos/webpos/static/sass/screen.scss
+++ b/pos/webpos/static/sass/screen.scss
@@ -156,6 +156,21 @@ main {
             white-space: nowrap;
             font-weight: bold;
         }
+        .notes {
+            padding-left: 12px;
+            padding-right: 5px;
+            textarea {
+                resize: none;
+                overflow: hidden;
+                @include single-transition(height, 200ms);
+                width: 100%;
+                height: 1em;
+                &:focus {
+                    overflow: auto;
+                    height: 5em;
+                }
+            }
+        }
     }
     footer {
         clear: both;

--- a/pos/webpos/static/sass/screen.scss
+++ b/pos/webpos/static/sass/screen.scss
@@ -69,7 +69,7 @@ main {
     header {
         height: 10px;//90px;
         text-align: center;
-        background: url('http://www.paeseinfesta.it/templates/sonne/css/images/Header.png') center top;
+        // background: url('http://www.paeseinfesta.it/templates/sonne/css/images/Header.png') center top;
     }
     section {
     }

--- a/pos/webpos/templates/webpos/order.html
+++ b/pos/webpos/templates/webpos/order.html
@@ -29,9 +29,9 @@
                 </ul>
             </article>
             <aside>
-                <form class="user-form">
+                <div class="user-form">
                     <input class="customer-name" type="text" name="username" autocomplete="off" placeholder="Nome cliente" />
-                </form>
+                </div>
                 <a href="#" class="btn-print-bill icon-print disabled"></a>
                 <table cellpadding="0" cellspacing="0" class="billItems">
                     <template class="billCategoryRow">

--- a/pos/webpos/templates/webpos/order.html
+++ b/pos/webpos/templates/webpos/order.html
@@ -48,6 +48,12 @@
                         <td class="item">{ name }</td>
                         <td class="price">{ price } &euro;</td>
                     </template>
+                    <template class="billItemNotes">
+                        <td></td>
+                        <td class="notes" colspan="3">
+                            <textarea class="item-notes" data-id="{ id }">{ notes }</textarea>
+                        </td>
+                    </template>
                     <template class="billSeparatorRow">
                         <td colspan="4">
                             <hr />


### PR DESCRIPTION
Is now possible to add notes to every single bill item. The JSON committed to the server is now formatted so:

```javascript

{
    "customer_name":"Customer name",
    "items":{
        "Acqua in caraffa":{
            "qty":1,
            "notes":""
        },
        "Lambrusco Semisecco":{
            "qty":1,
            "notes":"aaaaaaaaaaaaaaaaaa"
        },
        "Prosecco":{
            "qty":1,
            "notes":"aaaaaaaaaaaaaaaaaaaaaaaaaaa"
        },
        "Acqua FRIZ 1.5L":{
            "qty":1,
            "notes":"aasa as asa as a\n as\na \na\n s\nas \na\ns a"
        }
    }
}
```

Also fixes https://github.com/thedos1701/OpenGenfri/issues/39